### PR TITLE
Added Currency Validator to show Utrust only for specified base currencies

### DIFF
--- a/Observer/CurrencyValidator.php
+++ b/Observer/CurrencyValidator.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utrust\Payment\Observer;
+
+use Magento\Framework\DataObject;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Payment\Model\MethodInterface;
+use Magento\Quote\Api\Data\CartInterface;
+use Magento\Quote\Model\Quote;
+use Utrust\Payment\Model\Payment\Utrust;
+use Utrust\Payment\Service\Config;
+
+class CurrencyValidator implements ObserverInterface
+{
+    /**
+     * @var Config
+     */
+    private $config;
+
+    /**
+     * CurrencyValidator constructor.
+     * @param Config $config
+     */
+    public function __construct(Config $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * @param Observer $observer
+     */
+    public function execute(Observer $observer)
+    {
+        /** @var MethodInterface $methodInstance */
+        $methodInstance = $observer->getData('method_instance');
+
+        if ('utrust' !== $methodInstance->getCode()) {
+            return;
+        }
+
+        /** @var CartInterface|Quote $quote */
+        $quote = $observer->getData('quote');
+
+        /** @var DataObject $result */
+        $result = $observer->getData('result');
+
+        $availableCurrencies = $this->config->getAvailableCurrencies();
+
+        if (empty($availableCurrencies)) {
+            $result->setData('is_available', true);
+        } else {
+            $result->setData('is_available', in_array($quote->getBaseCurrencyCode(), $availableCurrencies));
+        }
+    }
+}

--- a/Service/Config.php
+++ b/Service/Config.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utrust\Payment\Service;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+
+class Config
+{
+    const XML_PATH_CURRENCY = 'payment/utrust/currency';
+
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    /**
+     * Config constructor.
+     * @param ScopeConfigInterface $scopeConfig
+     */
+    public function __construct(ScopeConfigInterface $scopeConfig)
+    {
+        $this->scopeConfig = $scopeConfig;
+    }
+
+    /**
+     * @param null $store
+     * @return array
+     */
+    public function getAvailableCurrencies($store = null): array
+    {
+        $result = $this->scopeConfig->getValue(
+            self::XML_PATH_CURRENCY,
+            ScopeConfigInterface::SCOPE_TYPE_DEFAULT,
+            $store
+        );
+
+        if (!empty($result)) {
+            return explode(',', $result);
+        } else {
+            return [];
+        }
+    }
+}

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -10,6 +10,7 @@
 				<instructions>You will get redirected to the Utrust payment widget.</instructions>
 				<allowspecific>0</allowspecific>
 				<group>offline</group>
+				<currency>USD,EUR,GBP</currency>
 			</utrust>
 		</payment>
 	</default>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+    <event name="payment_method_is_active">
+        <observer name="payment_method_is_active_utrust_currency_validator"
+                  instance="Utrust\Payment\Observer\CurrencyValidator" />
+    </event>
+</config>


### PR DESCRIPTION
In this pull request:
* Added currency validator for the Utrust payment method. The Quote Base Currency Code is checked against the list of supported currencies (specified in the config.xml file) and sets the "is_available" flag.
* The observer to the "payment_method_is_active" event is used to add the Currency Validation logic.
* The Utrust payment method is marked as available in case the currency list is empty in the config.xml file.
* Additional currencies can be added to the list of supported Merchant currencies. See the payment/utrust/currency XML node in the etc/config.xml file.
* Supported currencies: USD, GBP, and EUR