### PR TITLE
Removed restricted countries from the "Payment from Applicable Countries" setting

### DIFF
--- a/Config/Source/Country.php
+++ b/Config/Source/Country.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utrust\Payment\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+use Magento\Directory\Model\ResourceModel\Country\Collection;
+use Utrust\Payment\Service\Config;
+
+class Country implements OptionSourceInterface
+{
+    /**
+     * @var array
+     */
+    private $options;
+
+    /**
+     * @var Collection
+     */
+    private $countryCollection;
+
+    /**
+     * @var Config
+     */
+    private $config;
+
+    /**
+     * Country constructor.
+     * @param Collection $countryCollection
+     * @param Config $config
+     */
+    public function __construct(
+        Collection $countryCollection,
+        Config $config
+    ) {
+        $this->countryCollection = $countryCollection;
+        $this->config = $config;
+    }
+
+    /**
+     * @return array
+     */
+    public function toOptionArray(): array
+    {
+        if (!$this->options) {
+            $options = $this->countryCollection->loadData()->toOptionArray(
+                false
+            );
+
+            $this->options = array_filter(
+                $options,
+                function ($option) {
+                    return !in_array($option['value'], $this->config->getRestrictedCountryCodes()) ?
+                        $option :
+                        null;
+                }
+            );
+        }
+
+        return $this->options;
+    }
+}

--- a/Service/Config.php
+++ b/Service/Config.php
@@ -10,6 +10,7 @@ class Config
 {
     const XML_PATH_CURRENCY = 'payment/utrust/currency';
     const XML_PATH_INSTRUCTIONS = 'payment/utrust/instructions';
+    const XML_PATH_RESTRICTED_COUNTRY_CODES = 'payment/utrust/restricted_country_codes';
 
     /**
      * @var ScopeConfigInterface
@@ -31,17 +32,13 @@ class Config
      */
     public function getAvailableCurrencies($store = null): array
     {
-        $result = $this->scopeConfig->getValue(
+        $result = (string) $this->scopeConfig->getValue(
             self::XML_PATH_CURRENCY,
             ScopeConfigInterface::SCOPE_TYPE_DEFAULT,
             $store
         );
 
-        if (!empty($result)) {
-            return explode(',', $result);
-        } else {
-            return [];
-        }
+        return !empty($result) ? explode(',', $result) : [];
     }
 
     /**
@@ -55,5 +52,20 @@ class Config
             ScopeConfigInterface::SCOPE_TYPE_DEFAULT,
             $store
         );
+    }
+
+    /**
+     * @param null $store
+     * @return array
+     */
+    public function getRestrictedCountryCodes($store = null): array
+    {
+        $codes = (string) $this->scopeConfig->getValue(
+            self::XML_PATH_RESTRICTED_COUNTRY_CODES,
+            ScopeConfigInterface::SCOPE_TYPE_DEFAULT,
+            $store
+        );
+
+        return !empty($codes) ? explode(',', $codes) : [];
     }
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -51,11 +51,13 @@
 					<field id="allowspecific" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="42" translate="label" type="allowspecific">
 						<label>Payment from Applicable Countries</label>
 						<source_model>Magento\Payment\Model\Config\Source\Allspecificcountries</source_model>
+						<config_path>payment/utrust/allowspecific</config_path>
 					</field>
 					<field id="specificcountry" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="43" translate="label" type="multiselect">
 						<label>Payment from Applicable Countries</label>
-						<source_model>Magento\Directory\Model\Config\Source\Country</source_model>
+						<source_model>Utrust\Payment\Config\Source\Country</source_model>
 						<can_be_empty>1</can_be_empty>
+						<config_path>payment/utrust/specificcountry</config_path>
 					</field>
 				</group>
 				<group id="frontend" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="50" translate="label">

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -11,6 +11,7 @@
 				<allowspecific>0</allowspecific>
 				<group>offline</group>
 				<currency>USD,EUR,GBP</currency>
+				<restricted_country_codes>AX,AQ,AW,BS,BW,BV,IO,VG,CF,CX,CC,CK,CU,CW,KP,ET,FK,GF,PF,TF,GH,GL,GP,GU,HM,IR,XK,LY,MQ,YT,NC,NU,NF,MP,PK,PN,RE,BL,PM,RS,SO,LK,SD,SJ,SY,TK,TT,TN,UM,VI,VE,WF,EH,YE,CI</restricted_country_codes>
 			</utrust>
 		</payment>
 	</default>


### PR DESCRIPTION
In this pull request:
 - removed restricted countries from the "Payment from Applicable Countries" setting
 - fixed config paths for Allow Specific and Specific Countries
 - improved the getAvailableCurrencies() method

The restricted countries list codes are added via the `etc/config.xml` configuration file. For the additional countries, the `restricted_country_codes` node should be updated.