### PR TITLE
Added Magento Coding Standard package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+vendor/
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,33 @@
         }
     ],
     "minimum-stability": "dev",
-    "require": {},
+    "require": {
+        "magento/framework": "100.0.*|100.1.*|101.0.*|102.0.*"
+    },
     "autoload": {
         "psr-4": {
             "Utrust\\Payment\\": ""
         },
         "files": [
             "registration.php"
+        ]
+    },
+    "require-dev": {
+        "magento/magento-coding-standard": "dev-master"
+    },
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "https://repo.magento.com/"
+        }
+    ],
+    "scripts": {
+        "test-phpcs": " vendor/bin/phpcs --ignore=/vendor/ --standard=Magento2 .",
+        "post-install-cmd": [
+            "([ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/)"
+        ],
+        "post-update-cmd": [
+            "([ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/)"
         ]
     }
 }


### PR DESCRIPTION
In this pull request:
- Added Magento Coding Standard package
- Added "magento/framework" dependency
- Added a new command to be executed via the composer. The `test-phpcs` checks the source code of the extension against Magento 2 Coding Standards for possible issues and reports as the result of the execution.

Results from running the `composer test-phpcs" command:
```bash
>  vendor/bin/phpcs --ignore=/vendor/ --standard=Magento2 .

FILE: app/code/Utrust/Payment/Model/Api.php
----------------------------------------------------------------------
FOUND 0 ERRORS AND 8 WARNINGS AFFECTING 8 LINES
----------------------------------------------------------------------
 27 | WARNING | The use of function curl_init() is discouraged
 28 | WARNING | The use of function curl_setopt() is discouraged
 29 | WARNING | The use of function curl_setopt() is discouraged
 30 | WARNING | The use of function curl_setopt() is discouraged
 31 | WARNING | The use of function curl_setopt() is discouraged
 32 | WARNING | The use of function curl_setopt() is discouraged
 35 | WARNING | The use of function curl_exec() is discouraged
 36 | WARNING | The use of function curl_close() is discouraged
----------------------------------------------------------------------

Time: 1.42 secs; Memory: 8MB

```