### PR TITLE
Removed curl_init() and json_encode() PHP function usages in favour of Magento\Framework

### DIFF
--- a/Gateway/Config.php
+++ b/Gateway/Config.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utrust\Payment\Gateway;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\ScopeInterface;
+
+class Config
+{
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    /**
+     * @var array
+     */
+    private $config;
+
+    /**
+     * Config constructor.
+     * @param ScopeConfigInterface $scopeConfig
+     * @param array $config
+     */
+    public function __construct(
+        ScopeConfigInterface $scopeConfig,
+        array $config = []
+    ) {
+        $this->scopeConfig = $scopeConfig;
+        $this->config = $config;
+    }
+
+    /**
+     * @param null $storeId
+     * @return string
+     */
+    public function getApiUrl($storeId = null): string
+    {
+        $sandbox = $this->scopeConfig->getValue(
+            'payment/utrust/credentials/sandbox',
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+
+        return (string) ($sandbox ? $this->config['api_url_sandbox'] : $this->config['api_url']);
+    }
+
+    /**
+     * @param null $storeId
+     * @return string
+     */
+    public function getApiKey($storeId = null): string
+    {
+        return (string) $this->scopeConfig->getValue(
+            'payment/utrust/credentials/api_key',
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/ObjectManager/etc/config.xsd">
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <type name="Utrust\Payment\Logger\Handler">
         <arguments>
             <argument name="filesystem" xsi:type="object">Magento\Framework\Filesystem\Driver\File</argument>
@@ -12,6 +12,15 @@
             <argument name="name" xsi:type="string">utrust</argument>
             <argument name="handlers"  xsi:type="array">
                 <item name="system" xsi:type="object">Utrust\Payment\Logger\Handler</item>
+            </argument>
+        </arguments>
+    </type>
+
+    <type name="Utrust\Payment\Gateway\Config">
+        <arguments>
+            <argument name="config"  xsi:type="array">
+                <item name="api_url" xsi:type="string">https://merchants.api.utrust.com/api</item>
+                <item name="api_url_sandbox" xsi:type="string">https://merchants.api.sandbox-utrust.com/api</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
In this pull request:
* Replaced usages of the `json_encode()` and `json_decode()` functions to `SerializerInterface`
* Replaced usages of curl_ functions to ClientInterface
* Removed constants `API_SANDBOX_URL` and `API_PRODUCTION_URL`
* Moved API Urls to `di.xml` configuration
* Fixed xsi:noNamespaceSchemaLocation for `the etc/di.xml`