### PR TITLE
Added Magento 2 dependencies to the require section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,13 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "magento/framework": "100.0.*|100.1.*|101.0.*|102.0.*"
+        "magento/framework": "100.1.*|101.0.*|102.0.*",
+        "magento/module-store": "100.1.*|100.2.*|100.3.*",
+        "magento/module-sales": "100.1.*|101.0.*|102.0.*",
+        "magento/module-payment": "100.1.*|100.2.*|100.3.*",
+        "magento/module-checkout": "100.1.*|100.2.*|100.3.*",
+        "magento/module-quote": "100.1.*|101.0.*|101.1.*",
+        "magento/module-directory": "100.1.*|100.2.*|100.3.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
In this pull request:
* Added Magento 2 module dependencies into the composer.json file. It includes Magento 2.1, 2.2, and 2.3 editions