### PR TITLE
Fix arrayFlatten

### DIFF
--- a/Controller/Payment/Cancel.php
+++ b/Controller/Payment/Cancel.php
@@ -29,7 +29,7 @@ class Cancel extends \Magento\Framework\App\Action\Action
         $order = $this->checkoutSession->getLastRealOrder();
         if ($order) {
             $order->cancel()->setState(\Magento\Sales\Model\Order::STATE_CANCELED);
-            $order->addStatusToHistory($order->getStatus(), 'Gateway has canceled the payment.');
+            $order->addStatusToHistory($order->getStatus(), 'Utrust has canceled the payment (buyer clicked canceled button).');
             $order->save();
             $items = $order->getItemsCollection();
             foreach ($items as $item) {

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -95,13 +95,12 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     {
         $result = [];
         foreach ($array as $key => $value) {
-            if (is_object($value)) {
+            if (is_array($value)) {
                 foreach ($value as $k => $v) {
-                    $result[] = $key;
-                    $result[] = $k . $v;
+                    $result[$key . $k] = $v;
                 }
             } else {
-                $result[] = $key . $value;
+                $result[$key] = $value;
             }
         }
         return $result;


### PR DESCRIPTION
# Why
* The Json payload is decoded into Arrays, the arrayFlatten is incorrect because it's expecting that the nested arrays are objects ("is_object"). But they are Arrays.

# What
* Fixes the arrayFlatten logic 
* Add error messages and statuses when the webhook fails
